### PR TITLE
feat: add budget entries management

### DIFF
--- a/app/components/budget/EntryModal.vue
+++ b/app/components/budget/EntryModal.vue
@@ -1,0 +1,184 @@
+<template>
+  <dialog :open="open" class="modal">
+    <form method="dialog" class="modal-box" @submit.prevent="saveEntry">
+      <h3 class="font-bold text-lg">
+        {{ headerTitle }} {{ formatAmount(total, baseCurrency) }}
+      </h3>
+      <div class="mt-4 space-y-4">
+        <div
+          v-for="entry in localEntries"
+          :key="entry.id"
+          class="flex items-center justify-between"
+        >
+          <div>
+            <div class="font-medium">
+              {{ getDescription(entry) }}
+            </div>
+            <div class="text-sm opacity-70">
+              {{ formatAmount(entry.amount, entry.currency) }}
+            </div>
+          </div>
+          <div class="flex gap-2">
+            <button
+              type="button"
+              class="btn btn-sm"
+              @click="edit(entry)">
+              ✏️
+            </button>
+            <button
+              type="button"
+              class="btn btn-sm btn-error"
+              @click="remove(entry.id)">
+              🗑️
+            </button>
+          </div>
+        </div>
+        <div class="divider" />
+        <input
+          v-model="form.description"
+          class="input input-bordered w-full"
+          placeholder="Описание"
+        />
+        <input
+          v-model.number="form.amount"
+          type="number"
+          class="input input-bordered w-full"
+          placeholder="Сумма"
+        />
+        <input
+          v-model="form.currency"
+          class="input input-bordered w-full"
+          placeholder="Валюта"
+        />
+        <input
+          v-if="showDate"
+          v-model="form.date"
+          type="date"
+          class="input input-bordered w-full"
+        />
+      </div>
+      <div class="modal-action">
+        <button
+          type="button"
+          class="btn"
+          @click="close">
+          Отмена
+        </button>
+        <button type="submit" class="btn btn-primary">
+          Сохранить
+        </button>
+      </div>
+    </form>
+  </dialog>
+</template>
+
+<script setup lang="ts">
+import { calculateTotalBalance, formatAmount } from '~~/shared/utils/budget'
+import type { BalanceSourceData, IncomeEntryData, ExpenseEntryData } from '~~/shared/types/budget'
+
+type Entry = BalanceSourceData | IncomeEntryData | ExpenseEntryData
+
+interface Props {
+  modelValue: boolean
+  kind: 'balance' | 'income' | 'expense'
+  entries: Entry[]
+  monthId: string
+  baseCurrency: string
+  rates: Record<string, number>
+}
+
+const props = defineProps<Props>()
+const emit = defineEmits<{
+  (e: 'update:modelValue', v: boolean): void
+  (e: 'change', entries: Entry[]): void
+}>()
+
+const open = useVModel(props, 'modelValue')
+
+const localEntries = ref<Entry[]>([...props.entries])
+watch(() => props.entries, v => {
+  localEntries.value = [...v]
+})
+
+const showDate = computed(() => props.kind !== 'balance')
+
+const form = ref({ id: '', description: '', amount: 0, currency: props.baseCurrency, date: '' })
+
+const resetForm = () => {
+  form.value = { id: '', description: '', amount: 0, currency: props.baseCurrency, date: '' }
+}
+
+const headerTitle = computed(() => {
+  if (props.kind === 'balance') return 'Баланс'
+  if (props.kind === 'income') return 'Доходы'
+  return 'Расходы'
+})
+
+const getDescription = (entry: Entry) => {
+  return 'name' in entry ? entry.name : entry.description
+}
+
+const total = computed(() => {
+  const mapped = localEntries.value.map(e => ({
+    id: e.id,
+    name: getDescription(e),
+    currency: e.currency,
+    amount: e.amount,
+  }))
+  return calculateTotalBalance(mapped, props.baseCurrency, props.rates)
+})
+
+const close = () => {
+  open.value = false
+  resetForm()
+}
+
+const edit = (entry: Entry) => {
+  form.value = {
+    id: entry.id,
+    description: getDescription(entry),
+    amount: entry.amount,
+    currency: entry.currency,
+    date: 'date' in entry ? entry.date || '' : '',
+  }
+}
+
+const remove = async (id: string) => {
+  await $fetch(`/api/budget/entry/${id}`, { method: 'DELETE' })
+  localEntries.value = localEntries.value.filter(e => e.id !== id)
+  emit('change', localEntries.value)
+}
+
+const saveEntry = async () => {
+  if (!form.value.description || !form.value.amount || !form.value.currency) return
+  if (form.value.id) {
+    const updated = await $fetch<Entry>(`/api/budget/entry/${form.value.id}`, {
+      method: 'PUT',
+      body: {
+        description: form.value.description,
+        amount: form.value.amount,
+        currency: form.value.currency,
+        date: form.value.date || undefined,
+      },
+    })
+    localEntries.value = localEntries.value.map(e => e.id === updated.id ? updated : e)
+  }
+  else {
+    const created = await $fetch<Entry>('/api/budget/entry', {
+      method: 'POST',
+      body: {
+        monthId: props.monthId,
+        kind: props.kind,
+        description: form.value.description,
+        amount: form.value.amount,
+        currency: form.value.currency,
+        date: form.value.date || undefined,
+      },
+    })
+    localEntries.value = localEntries.value.concat(created)
+  }
+  emit('change', localEntries.value)
+  close()
+}
+</script>
+

--- a/app/components/budget/Month.vue
+++ b/app/components/budget/Month.vue
@@ -124,14 +124,43 @@
           </div>
         </div>
       </div>
+      <EntryModal
+        v-model="balanceModalOpen"
+        kind="balance"
+        :entries="monthData.balanceSources"
+        :month-id="monthData.userMonthId"
+        :base-currency="baseCurrency"
+        :rates="currentMonthRates"
+        @change="updateBalance"
+      />
+      <EntryModal
+        v-model="incomeModalOpen"
+        kind="income"
+        :entries="monthData.incomeEntries"
+        :month-id="monthData.userMonthId"
+        :base-currency="baseCurrency"
+        :rates="currentMonthRates"
+        @change="updateIncome"
+      />
+      <EntryModal
+        v-model="expenseModalOpen"
+        kind="expense"
+        :entries="monthData.expenseEntries"
+        :month-id="monthData.userMonthId"
+        :base-currency="baseCurrency"
+        :rates="currentMonthRates"
+        @change="updateExpense"
+      />
     </div>
     <hr>
   </li>
 </template>
 
 <script setup lang="ts">
-import type { MonthData } from '~~/shared/types/budget'
+import type { MonthData, BalanceSourceData, IncomeEntryData, ExpenseEntryData } from '~~/shared/types/budget'
 import { formatAmount, calculateTotalBalance, getBalanceChangeClass, getPocketExpensesClass } from '~~/shared/utils/budget'
+import EntryModal from '~/components/budget/EntryModal.vue'
+import { useAuthState } from '~/composables/useAuthState'
 
 interface Props {
   monthData: MonthData
@@ -141,7 +170,8 @@ interface Props {
 
 const props = defineProps<Props>()
 
-const baseCurrency = 'RUB'
+const { user } = useAuthState()
+const baseCurrency = computed(() => user.value?.mainCurrency || 'USD')
 
 const currentMonthRates = computed(() => {
   return props.exchangeRates || {}
@@ -150,7 +180,7 @@ const currentMonthRates = computed(() => {
 const startBalance = computed(() => {
   return calculateTotalBalance(
     props.monthData.balanceSources,
-    baseCurrency,
+    baseCurrency.value,
     currentMonthRates.value,
   )
 })
@@ -163,7 +193,7 @@ const totalIncome = computed(() => {
       currency: entry.currency,
       amount: entry.amount,
     })),
-    baseCurrency,
+    baseCurrency.value,
     currentMonthRates.value,
   )
 })
@@ -176,20 +206,36 @@ const totalExpenses = computed(() => {
       currency: entry.currency,
       amount: entry.amount,
     })),
-    baseCurrency,
+    baseCurrency.value,
     currentMonthRates.value,
   )
 })
 
-const openBalanceModal = (): void => {
-  console.log('Открытие модала баланса для месяца:', props.monthData.month + 1, props.monthData.year)
+const balanceModalOpen = ref(false)
+const incomeModalOpen = ref(false)
+const expenseModalOpen = ref(false)
+
+const openBalanceModal = () => {
+  balanceModalOpen.value = true
 }
 
-const openIncomeModal = (): void => {
-  console.log('Открытие модала доходов для месяца:', props.monthData.month + 1, props.monthData.year)
+const openIncomeModal = () => {
+  incomeModalOpen.value = true
 }
 
-const openExpenseModal = (): void => {
-  console.log('Открытие модала расходов для месяца:', props.monthData.month + 1, props.monthData.year)
+const openExpenseModal = () => {
+  expenseModalOpen.value = true
+}
+
+const updateBalance = (entries: BalanceSourceData[]) => {
+  props.monthData.balanceSources = entries
+}
+
+const updateIncome = (entries: IncomeEntryData[]) => {
+  props.monthData.incomeEntries = entries
+}
+
+const updateExpense = (entries: ExpenseEntryData[]) => {
+  props.monthData.expenseEntries = entries
 }
 </script>

--- a/app/components/budget/Month.vue
+++ b/app/components/budget/Month.vue
@@ -157,8 +157,18 @@
 </template>
 
 <script setup lang="ts">
-import type { MonthData, BalanceSourceData, IncomeEntryData, ExpenseEntryData } from '~~/shared/types/budget'
-import { formatAmount, calculateTotalBalance, getBalanceChangeClass, getPocketExpensesClass } from '~~/shared/utils/budget'
+import type {
+  MonthData,
+  BalanceSourceData,
+  IncomeEntryData,
+  ExpenseEntryData,
+} from '~~/shared/types/budget'
+import {
+  formatAmount,
+  calculateTotalBalance,
+  getBalanceChangeClass,
+  getPocketExpensesClass,
+} from '~~/shared/utils/budget'
 import EntryModal from '~/components/budget/EntryModal.vue'
 import { useAuthState } from '~/composables/useAuthState'
 
@@ -169,6 +179,11 @@ interface Props {
 }
 
 const props = defineProps<Props>()
+const emit = defineEmits<{
+  (e: 'updateBalance', entries: BalanceSourceData[]): void
+  (e: 'updateIncome', entries: IncomeEntryData[]): void
+  (e: 'updateExpense', entries: ExpenseEntryData[]): void
+}>()
 
 const { user } = useAuthState()
 const baseCurrency = computed(() => user.value?.mainCurrency || 'USD')
@@ -228,14 +243,14 @@ const openExpenseModal = () => {
 }
 
 const updateBalance = (entries: BalanceSourceData[]) => {
-  props.monthData.balanceSources = entries
+  emit('updateBalance', entries)
 }
 
 const updateIncome = (entries: IncomeEntryData[]) => {
-  props.monthData.incomeEntries = entries
+  emit('updateIncome', entries)
 }
 
 const updateExpense = (entries: ExpenseEntryData[]) => {
-  props.monthData.expenseEntries = entries
+  emit('updateExpense', entries)
 }
 </script>

--- a/app/components/budget/Year.vue
+++ b/app/components/budget/Year.vue
@@ -29,11 +29,19 @@
     :month-data="monthData"
     :month-names="monthNames"
     :exchange-rates="getCurrentRates(monthData)"
+    @update-balance="entries => emit('updateBalance', monthData, entries)"
+    @update-income="entries => emit('updateIncome', monthData, entries)"
+    @update-expense="entries => emit('updateExpense', monthData, entries)"
   />
 </template>
 
 <script setup lang="ts">
-import type { MonthData } from '~~/shared/types/budget'
+import type {
+  MonthData,
+  BalanceSourceData,
+  IncomeEntryData,
+  ExpenseEntryData,
+} from '~~/shared/types/budget'
 
 interface Props {
   year: number
@@ -43,6 +51,11 @@ interface Props {
 }
 
 const props = defineProps<Props>()
+const emit = defineEmits<{
+  (e: 'updateBalance', month: MonthData, entries: BalanceSourceData[]): void
+  (e: 'updateIncome', month: MonthData, entries: IncomeEntryData[]): void
+  (e: 'updateExpense', month: MonthData, entries: ExpenseEntryData[]): void
+}>()
 
 const getCurrentRates = (monthData: MonthData): Record<string, number> => {
   const rateDate = `${monthData.year}-${String(monthData.month + 1).padStart(2, '0')}-01`

--- a/app/pages/budget.vue
+++ b/app/pages/budget.vue
@@ -45,7 +45,11 @@
   </div>
 </template>
 
-<script setup>
+<script setup lang="ts">
+import type { MonthData } from '~~/shared/types/budget'
+import { calculateTotalBalance } from '~~/shared/utils/budget'
+import { useAuthState } from '~/composables/useAuthState'
+
 const monthNames = [
   'январь', 'февраль', 'март', 'апрель', 'май', 'июнь',
   'июль', 'август', 'сентябрь', 'октябрь', 'ноябрь', 'декабрь',
@@ -55,57 +59,78 @@ const now = new Date()
 const currentYear = now.getFullYear()
 const currentMonth = now.getMonth()
 
+const { user } = useAuthState()
+const baseCurrency = computed(() => user.value?.mainCurrency || 'USD')
+
 const isCreatingCurrentMonth = ref(false)
 
-const monthsData = ref([])
+const monthsData = ref<MonthData[]>([])
 
-const exchangeRates = ref({
-  '2024-01-01': {
-    USD: 1,
-    EUR: 0.85,
-    RUB: 75,
-  },
-})
+const exchangeRates = ref<Record<string, Record<string, number>>>({})
 
 const groupedData = computed(() => {
-  return monthsData.value.reduce((acc, month) => {
-    if (!acc[month.year]) {
-      acc[month.year] = []
+  return monthsData.value.reduce((acc: Record<number, MonthData[]>, m) => {
+    if (!acc[m.year]) {
+      acc[m.year] = []
     }
-    acc[month.year].push(month)
+    acc[m.year] = acc[m.year].concat(m)
     return acc
   }, {})
 })
 
 const years = computed(() => {
-  return Object.keys(groupedData.value)
-    .map(Number)
-    .sort((a, b) => b - a)
+  return Object.keys(groupedData.value).map(Number).sort((a, b) => b - a)
 })
+
+const computeStats = () => {
+  const sorted = [...monthsData.value].sort((a, b) => {
+    if (a.year === b.year) return a.month - b.month
+    return a.year - b.year
+  })
+  sorted.forEach((m, i) => {
+    const rateDate = `${m.year}-${String(m.month + 1).padStart(2, '0')}-01`
+    const rates = exchangeRates.value[rateDate] || {}
+    const incomeTotal = calculateTotalBalance(
+      m.incomeEntries.map(e => ({ id: e.id, name: e.description, currency: e.currency, amount: e.amount })),
+      baseCurrency.value,
+      rates,
+    )
+    const expenseTotal = calculateTotalBalance(
+      m.expenseEntries.map(e => ({ id: e.id, name: e.description, currency: e.currency, amount: e.amount })),
+      baseCurrency.value,
+      rates,
+    )
+    const startBalance = calculateTotalBalance(m.balanceSources, baseCurrency.value, rates)
+    const prev = sorted[i - 1]
+    const prevRateDate = prev ? `${prev.year}-${String(prev.month + 1).padStart(2, '0')}-01` : ''
+    const prevBalance = prev
+      ? calculateTotalBalance(prev.balanceSources, baseCurrency.value, exchangeRates.value[prevRateDate] || {})
+      : 0
+    m.income = incomeTotal
+    m.balanceChange = incomeTotal - expenseTotal
+    m.pocketExpenses = prev ? prevBalance - startBalance + incomeTotal - expenseTotal : 0
+  })
+}
+
+const fetchData = async () => {
+  const data = await $fetch<{ months: MonthData[]; rates: Record<string, Record<string, number>> }>('/api/budget')
+  monthsData.value = data.months
+  exchangeRates.value = data.rates
+  computeStats()
+}
+
+onMounted(fetchData)
+
+watch(monthsData, computeStats, { deep: true })
 
 const createCurrentMonth = async () => {
   isCreatingCurrentMonth.value = true
-
   try {
-    await new Promise(resolve => setTimeout(resolve, 1000))
-
-    const newMonth = {
-      id: `month-${Date.now()}`,
-      year: currentYear,
-      month: currentMonth,
-      userMonthId: `user-month-${Date.now()}`,
-      balanceSources: [],
-      incomeEntries: [],
-      expenseEntries: [],
-      balanceChange: 0,
-      pocketExpenses: 0,
-      income: 0,
-    }
-
-    monthsData.value.push(newMonth)
-  }
-  catch (error) {
-    console.error('Error creating current month:', error)
+    const newMonth = await $fetch<MonthData>('/api/budget', {
+      method: 'POST',
+      body: { year: currentYear, month: currentMonth },
+    })
+    monthsData.value = monthsData.value.concat(newMonth)
   }
   finally {
     isCreatingCurrentMonth.value = false

--- a/app/pages/budget.vue
+++ b/app/pages/budget.vue
@@ -40,13 +40,21 @@
         :months="groupedData[year]"
         :month-names="monthNames"
         :exchange-rates="exchangeRates"
+        @update-balance="(month, entries) => onUpdateBalance(month, entries)"
+        @update-income="(month, entries) => onUpdateIncome(month, entries)"
+        @update-expense="(month, entries) => onUpdateExpense(month, entries)"
       />
     </ul>
   </div>
 </template>
 
 <script setup lang="ts">
-import type { MonthData } from '~~/shared/types/budget'
+import type {
+  MonthData,
+  BalanceSourceData,
+  IncomeEntryData,
+  ExpenseEntryData,
+} from '~~/shared/types/budget'
 import { calculateTotalBalance } from '~~/shared/utils/budget'
 import { useAuthState } from '~/composables/useAuthState'
 
@@ -110,6 +118,30 @@ const computeStats = () => {
     m.balanceChange = incomeTotal - expenseTotal
     m.pocketExpenses = prev ? prevBalance - startBalance + incomeTotal - expenseTotal : 0
   })
+}
+
+const onUpdateBalance = (
+  month: MonthData,
+  entries: BalanceSourceData[],
+) => {
+  month.balanceSources = entries
+  computeStats()
+}
+
+const onUpdateIncome = (
+  month: MonthData,
+  entries: IncomeEntryData[],
+) => {
+  month.incomeEntries = entries
+  computeStats()
+}
+
+const onUpdateExpense = (
+  month: MonthData,
+  entries: ExpenseEntryData[],
+) => {
+  month.expenseEntries = entries
+  computeStats()
 }
 
 const fetchData = async () => {

--- a/server/api/budget/entry/[id].delete.ts
+++ b/server/api/budget/entry/[id].delete.ts
@@ -1,0 +1,24 @@
+import { defineEventHandler, createError } from 'h3'
+import { eq } from 'drizzle-orm'
+import { db } from '~~/server/db'
+import { entry, month } from '~~/server/db/schema'
+import { requireAuth } from '~~/server/utils/session'
+
+export default defineEventHandler(async event => {
+  const user = await requireAuth(event)
+  const id = event.context.params?.id
+  if (!id) {
+    throw createError({ statusCode: 400, statusMessage: 'Missing id' })
+  }
+  const [existing] = await db.select().from(entry).where(eq(entry.id, id))
+  if (!existing) {
+    throw createError({ statusCode: 404, statusMessage: 'Not found' })
+  }
+  const [m] = await db.select().from(month).where(eq(month.id, existing.monthId))
+  if (!m || m.userId !== user.id) {
+    throw createError({ statusCode: 403, statusMessage: 'Forbidden' })
+  }
+  await db.delete(entry).where(eq(entry.id, id))
+  return { ok: true }
+})
+

--- a/server/api/budget/entry/[id].put.ts
+++ b/server/api/budget/entry/[id].put.ts
@@ -1,0 +1,38 @@
+import { defineEventHandler, createError } from 'h3'
+import { eq } from 'drizzle-orm'
+import { db } from '~~/server/db'
+import { entry, month } from '~~/server/db/schema'
+import { parseBody } from '~~/server/utils/validation'
+import { requireAuth } from '~~/server/utils/session'
+import { updateEntrySchema } from '~~/server/schemas/budget'
+
+export default defineEventHandler(async event => {
+  const user = await requireAuth(event)
+  const id = event.context.params?.id
+  if (!id) {
+    throw createError({ statusCode: 400, statusMessage: 'Missing id' })
+  }
+  const data = await parseBody(event, updateEntrySchema)
+  const [existing] = await db.select().from(entry).where(eq(entry.id, id))
+  if (!existing) {
+    throw createError({ statusCode: 404, statusMessage: 'Not found' })
+  }
+  const [m] = await db.select().from(month).where(eq(month.id, existing.monthId))
+  if (!m || m.userId !== user.id) {
+    throw createError({ statusCode: 403, statusMessage: 'Forbidden' })
+  }
+  await db.update(entry).set({
+    description: data.description,
+    amount: data.amount,
+    currency: data.currency,
+    date: data.date,
+  }).where(eq(entry.id, id))
+  return {
+    id,
+    description: data.description,
+    amount: data.amount,
+    currency: data.currency,
+    date: data.date || '',
+  }
+})
+

--- a/server/api/budget/entry/index.post.ts
+++ b/server/api/budget/entry/index.post.ts
@@ -1,0 +1,34 @@
+import { defineEventHandler, createError } from 'h3'
+import { eq } from 'drizzle-orm'
+import { db } from '~~/server/db'
+import { entry, month } from '~~/server/db/schema'
+import { parseBody } from '~~/server/utils/validation'
+import { requireAuth } from '~~/server/utils/session'
+import { createEntrySchema } from '~~/server/schemas/budget'
+
+export default defineEventHandler(async event => {
+  const user = await requireAuth(event)
+  const data = await parseBody(event, createEntrySchema)
+  const [m] = await db.select().from(month).where(eq(month.id, data.monthId))
+  if (!m || m.userId !== user.id) {
+    throw createError({ statusCode: 403, statusMessage: 'Forbidden' })
+  }
+  const id = crypto.randomUUID()
+  await db.insert(entry).values({
+    id,
+    monthId: data.monthId,
+    kind: data.kind,
+    description: data.description,
+    amount: data.amount,
+    currency: data.currency,
+    date: data.date,
+  })
+  return {
+    id,
+    description: data.description,
+    amount: data.amount,
+    currency: data.currency,
+    date: data.date || '',
+  }
+})
+

--- a/server/api/budget/index.get.ts
+++ b/server/api/budget/index.get.ts
@@ -1,0 +1,56 @@
+import { defineEventHandler } from 'h3'
+import { eq, inArray } from 'drizzle-orm'
+import { db } from '~~/server/db'
+import { month, entry, currency } from '~~/server/db/schema'
+import { requireAuth } from '~~/server/utils/session'
+
+export default defineEventHandler(async event => {
+  const user = await requireAuth(event)
+  const months = await db.select().from(month).where(eq(month.userId, user.id))
+  const ids = months.map(m => m.id)
+  const entries = ids.length === 0 ? [] : await db.select().from(entry).where(inArray(entry.monthId, ids))
+  const grouped = entries.reduce((acc, e) => {
+    const list = acc[e.monthId] || []
+    acc[e.monthId] = list.concat(e)
+    return acc
+  }, {} as Record<string, typeof entries>)
+  const monthsData = months.map(m => {
+    const list = grouped[m.id] || []
+    const balanceSources = list.filter(e => e.kind === 'balance').map(e => ({
+      id: e.id,
+      name: e.description,
+      amount: e.amount,
+      currency: e.currency,
+    }))
+    const incomeEntries = list.filter(e => e.kind === 'income').map(e => ({
+      id: e.id,
+      description: e.description,
+      amount: e.amount,
+      currency: e.currency,
+      date: e.date || '',
+    }))
+    const expenseEntries = list.filter(e => e.kind === 'expense').map(e => ({
+      id: e.id,
+      description: e.description,
+      amount: e.amount,
+      currency: e.currency,
+      date: e.date || '',
+    }))
+    return {
+      id: m.id,
+      year: m.year,
+      month: m.month,
+      userMonthId: m.id,
+      balanceSources,
+      incomeEntries,
+      expenseEntries,
+      balanceChange: 0,
+      pocketExpenses: 0,
+      income: 0,
+    }
+  })
+  const rateRows = await db.select().from(currency)
+  const rates = rateRows.reduce((acc, r) => ({ ...acc, [r.date]: r.rates as Record<string, number> }), {} as Record<string, Record<string, number>>)
+  return { months: monthsData, rates }
+})
+

--- a/server/api/budget/index.post.ts
+++ b/server/api/budget/index.post.ts
@@ -1,0 +1,28 @@
+import { defineEventHandler, createError } from 'h3'
+import { db } from '~~/server/db'
+import { month } from '~~/server/db/schema'
+import { parseBody } from '~~/server/utils/validation'
+import { requireAuth } from '~~/server/utils/session'
+import { createMonthSchema } from '~~/server/schemas/budget'
+
+export default defineEventHandler(async event => {
+  const user = await requireAuth(event)
+  const { year, month: m } = await parseBody(event, createMonthSchema)
+  const id = crypto.randomUUID()
+  await db.insert(month).values({ id, userId: user.id, year, month: m }).catch(() => {
+    throw createError({ statusCode: 400, statusMessage: 'Month exists' })
+  })
+  return {
+    id,
+    year,
+    month: m,
+    userMonthId: id,
+    balanceSources: [],
+    incomeEntries: [],
+    expenseEntries: [],
+    balanceChange: 0,
+    pocketExpenses: 0,
+    income: 0,
+  }
+})
+

--- a/server/schemas/budget.ts
+++ b/server/schemas/budget.ts
@@ -11,14 +11,14 @@ export const createEntrySchema = z.object({
   description: z.string().min(1),
   amount: z.number().int().nonnegative(),
   currency: z.string().length(3),
-  date: z.string().optional(),
+  date: z.string().date().optional(),
 })
 
 export const updateEntrySchema = z.object({
   description: z.string().min(1),
   amount: z.number().int().nonnegative(),
   currency: z.string().length(3),
-  date: z.string().optional(),
+  date: z.string().date().optional(),
 })
 
 export type CreateMonthInput = z.infer<typeof createMonthSchema>

--- a/server/schemas/budget.ts
+++ b/server/schemas/budget.ts
@@ -1,0 +1,27 @@
+import { z } from 'zod'
+
+export const createMonthSchema = z.object({
+  year: z.number().int(),
+  month: z.number().int().min(0).max(11),
+})
+
+export const createEntrySchema = z.object({
+  monthId: z.string().uuid(),
+  kind: z.enum(['balance', 'income', 'expense']),
+  description: z.string().min(1),
+  amount: z.number().int().nonnegative(),
+  currency: z.string().length(3),
+  date: z.string().optional(),
+})
+
+export const updateEntrySchema = z.object({
+  description: z.string().min(1),
+  amount: z.number().int().nonnegative(),
+  currency: z.string().length(3),
+  date: z.string().optional(),
+})
+
+export type CreateMonthInput = z.infer<typeof createMonthSchema>
+export type CreateEntryInput = z.infer<typeof createEntrySchema>
+export type UpdateEntryInput = z.infer<typeof updateEntrySchema>
+


### PR DESCRIPTION
## Summary
- add CRUD API for budget months and entries
- implement modal to manage balance, income, and expenses
- enhance budget page with data fetching and pocket expense calculations

## Testing
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_68976e01eb7c8329a9cee75f7de6d008