### PR TITLE
feat: add budget sharing ui

### DIFF
--- a/app/components/HeaderControls.vue
+++ b/app/components/HeaderControls.vue
@@ -1,0 +1,16 @@
+<template>
+  <div
+    v-if="controls.length"
+    class="flex gap-2 mr-2"
+  >
+    <component
+      :is="Control"
+      v-for="(Control, index) in controls"
+      :key="index"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+const controls = useHeaderControls()
+</script>

--- a/app/components/budget/BudgetHeaderControls.vue
+++ b/app/components/budget/BudgetHeaderControls.vue
@@ -1,0 +1,38 @@
+<template>
+  <div class="flex gap-2">
+    <button
+      v-if="sharedBudgets.length"
+      class="btn btn-secondary btn-sm"
+      @click="openSharedBudgets"
+    >
+      Ваши бюджеты
+    </button>
+    <button
+      class="btn btn-primary btn-sm"
+      @click="openShare"
+    >
+      Общий доступ
+    </button>
+    <BudgetShareModal ref="shareModal" />
+    <SharedBudgetsModal ref="sharedModal" />
+  </div>
+</template>
+
+<script setup lang="ts">
+import BudgetShareModal from '~/components/budget/BudgetShareModal.vue'
+import SharedBudgetsModal from '~/components/budget/SharedBudgetsModal.vue'
+import { useBudgetSharing } from '~/composables/useBudgetSharing'
+
+const { sharedBudgets } = useBudgetSharing()
+
+const shareModal = ref<InstanceType<typeof BudgetShareModal> | null>(null)
+const sharedModal = ref<InstanceType<typeof SharedBudgetsModal> | null>(null)
+
+const openShare = (): void => {
+  shareModal.value?.show()
+}
+
+const openSharedBudgets = (): void => {
+  sharedModal.value?.show()
+}
+</script>

--- a/app/components/budget/BudgetShareModal.vue
+++ b/app/components/budget/BudgetShareModal.vue
@@ -1,0 +1,272 @@
+<template>
+  <dialog
+    ref="modal"
+    class="modal"
+    @close="handleDialogClose"
+  >
+    <div class="modal-box w-11/12 max-w-5xl">
+      <button
+        type="button"
+        class="btn btn-sm btn-circle btn-ghost absolute right-2 top-2"
+        @click="hide()"
+      >
+        ✕
+      </button>
+      <h3 class="font-bold text-lg mb-4">
+        Общий доступ к вашему бюджету
+      </h3>
+      <div class="space-y-4 mb-6">
+        <div v-if="shares.length || isAddingNew">
+          <div class="overflow-x-auto">
+            <table class="table table-zebra">
+              <thead>
+                <tr>
+                  <th>Имя пользователя</th>
+                  <th>Уровень доступа</th>
+                  <th class="w-1">
+                    Действия
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr
+                  v-for="share in shares"
+                  :key="share.id"
+                >
+                  <td>
+                    <input
+                      v-if="editingId === share.id"
+                      v-model="editingShare.username"
+                      type="text"
+                      class="input input-sm input-bordered w-full"
+                      @keyup.enter="saveShare()"
+                      @keyup.esc="cancelEdit()"
+                    >
+                    <span v-else>{{ share.username }}</span>
+                  </td>
+                  <td>
+                    <select
+                      v-if="editingId === share.id"
+                      v-model="editingShare.access"
+                      class="select select-sm select-bordered w-full"
+                    >
+                      <option value="read">
+                        Только чтение
+                      </option>
+                      <option value="write">
+                        Чтение и редактирование
+                      </option>
+                    </select>
+                    <span v-else>{{ accessLabel(share.access) }}</span>
+                  </td>
+                  <td class="w-1">
+                    <div class="flex gap-2">
+                      <template v-if="editingId === share.id">
+                        <button
+                          class="btn btn-sm btn-success"
+                          :disabled="isSaving"
+                          @click="saveShare()"
+                        >
+                          <span
+                            v-if="isSaving"
+                            class="loading loading-spinner loading-xs"
+                          />
+                          <span v-else>✓</span>
+                        </button>
+                        <button
+                          class="btn btn-sm btn-ghost"
+                          @click="cancelEdit()"
+                        >
+                          ✕
+                        </button>
+                      </template>
+                      <template v-else>
+                        <button
+                          class="btn btn-sm btn-warning"
+                          @click="startEdit(share)"
+                        >
+                          ✏️
+                        </button>
+                        <button
+                          class="btn btn-sm btn-error"
+                          :disabled="isDeleting === share.id"
+                          @click="deleteShare(share.id)"
+                        >
+                          <span
+                            v-if="isDeleting === share.id"
+                            class="loading loading-spinner loading-xs"
+                          />
+                          <span v-else>🗑️</span>
+                        </button>
+                      </template>
+                    </div>
+                  </td>
+                </tr>
+                <tr v-if="isAddingNew">
+                  <td>
+                    <input
+                      v-model="newShare.username"
+                      type="text"
+                      placeholder="Имя пользователя"
+                      class="input input-sm input-bordered w-full"
+                      @keyup.enter="addShare()"
+                      @keyup.esc="cancelAdd()"
+                    >
+                  </td>
+                  <td>
+                    <select
+                      v-model="newShare.access"
+                      class="select select-sm select-bordered w-full"
+                    >
+                      <option value="read">
+                        Только чтение
+                      </option>
+                      <option value="write">
+                        Чтение и редактирование
+                      </option>
+                    </select>
+                  </td>
+                  <td class="w-1">
+                    <div class="flex gap-2">
+                      <button
+                        type="button"
+                        class="btn btn-sm btn-success"
+                        :disabled="isSaving"
+                        @click="addShare()"
+                      >
+                        <span
+                          v-if="isSaving"
+                          class="loading loading-spinner loading-xs"
+                        />
+                        <span v-else>✓</span>
+                      </button>
+                      <button
+                        type="button"
+                        class="btn btn-sm btn-ghost"
+                        @click="cancelAdd()"
+                      >
+                        ✕
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+        <div
+          v-else
+          class="text-center py-6 opacity-70"
+        >
+          Нет пользователей с доступом
+        </div>
+      </div>
+      <div class="modal-action">
+        <button
+          v-if="!isAddingNew"
+          class="btn btn-primary"
+          @click="startAdd"
+        >
+          Поделиться бюджетом с новым пользователем
+        </button>
+      </div>
+    </div>
+  </dialog>
+</template>
+
+<script setup lang="ts">
+import { useBudgetSharing, type BudgetShare } from '~/composables/useBudgetSharing'
+
+const { shares } = useBudgetSharing()
+
+const modal = ref<HTMLDialogElement | null>(null)
+const isAddingNew = ref(false)
+const isSaving = ref(false)
+const isDeleting = ref<number | null>(null)
+const editingId = ref<number | null>(null)
+
+const newShare = reactive<Omit<BudgetShare, 'id'>>({ username: '', access: 'read' })
+const editingShare = reactive<Omit<BudgetShare, 'id'>>({ username: '', access: 'read' })
+
+const startAdd = (): void => {
+  isAddingNew.value = true
+}
+
+const cancelAdd = (): void => {
+  isAddingNew.value = false
+  newShare.username = ''
+  newShare.access = 'read'
+}
+
+const addShare = async (): Promise<void> => {
+  if (!newShare.username.trim()) return
+  isSaving.value = true
+  try {
+    shares.value.push({ id: Date.now(), ...newShare })
+    // TODO отправить запрос на бэкенд для добавления пользователя
+    cancelAdd()
+  }
+  finally {
+    isSaving.value = false
+  }
+}
+
+const startEdit = (share: BudgetShare): void => {
+  editingId.value = share.id
+  editingShare.username = share.username
+  editingShare.access = share.access
+}
+
+const cancelEdit = (): void => {
+  editingId.value = null
+}
+
+const saveShare = async (): Promise<void> => {
+  if (editingId.value === null || !editingShare.username.trim()) return
+  isSaving.value = true
+  try {
+    const idx = shares.value.findIndex(s => s.id === editingId.value)
+    if (idx !== -1) {
+      shares.value[idx] = { id: editingId.value, ...editingShare }
+      // TODO отправить запрос на бэкенд для обновления доступа
+    }
+    cancelEdit()
+  }
+  finally {
+    isSaving.value = false
+  }
+}
+
+const deleteShare = async (id: number): Promise<void> => {
+  isDeleting.value = id
+  try {
+    shares.value = shares.value.filter(s => s.id !== id)
+    // TODO отправить запрос на бэкенд для удаления доступа
+  }
+  finally {
+    isDeleting.value = null
+  }
+}
+
+const accessLabel = (access: BudgetShare['access']): string => {
+  return access === 'write' ? 'Чтение и редактирование' : 'Только чтение'
+}
+
+const show = (): void => {
+  modal.value?.showModal()
+}
+
+const hide = (): void => {
+  modal.value?.close()
+}
+
+const handleDialogClose = (): void => {
+  cancelAdd()
+  cancelEdit()
+}
+
+defineExpose({
+  show,
+  hide,
+})
+</script>

--- a/app/components/budget/SharedBudgetsModal.vue
+++ b/app/components/budget/SharedBudgetsModal.vue
@@ -1,0 +1,107 @@
+<template>
+  <dialog
+    ref="modal"
+    class="modal"
+    @close="handleDialogClose"
+  >
+    <div class="modal-box w-11/12 max-w-2xl">
+      <button
+        type="button"
+        class="btn btn-sm btn-circle btn-ghost absolute right-2 top-2"
+        @click="hide()"
+      >
+        ✕
+      </button>
+      <h3 class="font-bold text-lg mb-4">
+        Бюджеты, которыми с вами поделились
+      </h3>
+      <div class="space-y-4 mb-6">
+        <div v-if="sharedBudgets.length">
+          <div class="overflow-x-auto">
+            <table class="table table-zebra">
+              <thead>
+                <tr>
+                  <th>Бюджет</th>
+                  <th class="w-1">
+                    Действия
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr
+                  v-for="budget in sharedBudgets"
+                  :key="budget.id"
+                >
+                  <td>
+                    <NuxtLink
+                      :to="`/budget/${budget.username}`"
+                      class="btn btn-sm btn-ghost"
+                    >
+                      Перейти к бюджету {{ budget.username }}
+                    </NuxtLink>
+                  </td>
+                  <td class="w-1">
+                    <button
+                      class="btn btn-sm btn-error"
+                      :disabled="isDeleting === budget.id"
+                      @click="removeAccess(budget.id)"
+                    >
+                      <span
+                        v-if="isDeleting === budget.id"
+                        class="loading loading-spinner loading-xs"
+                      />
+                      <span v-else>🗑️</span>
+                    </button>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+        <div
+          v-else
+          class="text-center py-6 opacity-70"
+        >
+          Нет бюджетов, которыми с вами поделились
+        </div>
+      </div>
+    </div>
+  </dialog>
+</template>
+
+<script setup lang="ts">
+import { useBudgetSharing } from '~/composables/useBudgetSharing'
+
+const { sharedBudgets } = useBudgetSharing()
+
+const modal = ref<HTMLDialogElement | null>(null)
+const isDeleting = ref<number | null>(null)
+
+const removeAccess = async (id: number): Promise<void> => {
+  isDeleting.value = id
+  try {
+    sharedBudgets.value = sharedBudgets.value.filter(b => b.id !== id)
+    // TODO отправить запрос на бэкенд для отказа от доступа
+  }
+  finally {
+    isDeleting.value = null
+  }
+}
+
+const show = (): void => {
+  modal.value?.showModal()
+}
+
+const hide = (): void => {
+  modal.value?.close()
+}
+
+const handleDialogClose = (): void => {
+  // no-op
+}
+
+defineExpose({
+  show,
+  hide,
+})
+</script>

--- a/app/composables/useBudgetSharing.ts
+++ b/app/composables/useBudgetSharing.ts
@@ -1,0 +1,15 @@
+export interface BudgetShare {
+  id: number
+  username: string
+  access: 'read' | 'write'
+}
+
+export const useBudgetSharing = () => {
+  const shares = useState<BudgetShare[]>('budget-shares', () => [])
+  const sharedBudgets = useState<BudgetShare[]>('shared-budgets', () => [])
+
+  return {
+    shares,
+    sharedBudgets,
+  }
+}

--- a/app/composables/useHeaderControls.ts
+++ b/app/composables/useHeaderControls.ts
@@ -1,0 +1,2 @@
+export const useHeaderControls = <T = unknown>() =>
+  useState<T[]>('header-controls', () => [])

--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -23,6 +23,7 @@
         </div>
       </div>
       <div class="navbar-end">
+        <HeaderControls />
         <div
           v-if="isAuthenticated"
           class="dropdown dropdown-end"

--- a/app/pages/budget.vue
+++ b/app/pages/budget.vue
@@ -61,6 +61,15 @@
 
 <script setup lang="ts">
 import type { MonthData } from '~~/shared/types/budget'
+import BudgetHeaderControls from '~/components/budget/BudgetHeaderControls.vue'
+
+const headerControls = useHeaderControls()
+onMounted(() => {
+  headerControls.value = [BudgetHeaderControls]
+})
+onUnmounted(() => {
+  headerControls.value = []
+})
 
 const monthNames = [
   'январь', 'февраль', 'март', 'апрель', 'май', 'июнь',


### PR DESCRIPTION
## Summary
- add header control slot and composable for page-specific actions
- implement budget sharing buttons and modals on budget page
- support managing shared budgets and access levels via UI

## Testing
- `pnpm lint`
- `pnpm test:run`


------
https://chatgpt.com/codex/tasks/task_e_689e5197b9148329adc19bbcc86e67a2